### PR TITLE
Add modern Linda Nova chat experience

### DIFF
--- a/linda_trendy_bot.html
+++ b/linda_trendy_bot.html
@@ -1,0 +1,435 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Linda Nova – KI-Bot in Motion</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg: #0b1021;
+      --panel: rgba(255, 255, 255, 0.04);
+      --muted: #c6c9e0;
+      --text: #e8ebff;
+      --line: rgba(255, 255, 255, 0.08);
+      --brand: #7ce7ff;
+      --brand-2: #d96bff;
+      --accent: linear-gradient(120deg, #7ce7ff, #d96bff);
+      --shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+      --radius: 14px;
+      --glass: blur(12px);
+      --success: #6dd8a3;
+    }
+    body.light {
+      --bg: #f8f9ff;
+      --panel: rgba(255, 255, 255, 0.9);
+      --muted: #5c5f7a;
+      --text: #1c2238;
+      --line: rgba(18, 24, 55, 0.08);
+      --brand: #0068ff;
+      --brand-2: #00c2ff;
+      --accent: linear-gradient(120deg, #0068ff, #00c2ff);
+      --shadow: 0 15px 40px rgba(0, 64, 160, 0.15);
+      --glass: blur(6px);
+      --success: #1e9e6b;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; min-height: 100%; background: radial-gradient(circle at 20% 20%, rgba(124, 231, 255, 0.15), transparent 30%), radial-gradient(circle at 80% 10%, rgba(217, 107, 255, 0.18), transparent 30%), var(--bg); color: var(--text); font-family: "Inter", system-ui, -apple-system, "Space Grotesk", sans-serif; }
+    a { color: var(--brand); }
+
+    .frame { max-width: 1400px; margin: 0 auto; padding: 32px 22px 42px; }
+    header { display: flex; align-items: center; gap: 16px; position: sticky; top: 0; z-index: 5; padding: 14px 16px; backdrop-filter: var(--glass); border: 1px solid var(--line); background: linear-gradient(120deg, rgba(124, 231, 255, 0.08), rgba(217, 107, 255, 0.08)); border-radius: 16px; box-shadow: var(--shadow); }
+    .logo { width: 44px; height: 44px; border-radius: 12px; background: var(--accent); display: grid; place-items: center; font-weight: 700; color: #0c1024; letter-spacing: -0.02em; }
+    .title { font-size: 1.2rem; font-weight: 700; letter-spacing: -0.02em; }
+    .badge { padding: 8px 12px; border-radius: 999px; border: 1px solid var(--line); color: var(--text); background: var(--panel); display: inline-flex; align-items: center; gap: 8px; font-weight: 600; }
+    .pill { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; background: rgba(255, 255, 255, 0.06); border-radius: 999px; border: 1px solid var(--line); color: var(--text); }
+    .pill small { color: var(--muted); font-weight: 500; }
+
+    main { display: grid; grid-template-columns: 360px 1fr; gap: 22px; margin-top: 22px; }
+
+    .panel { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); padding: 18px 18px 16px; backdrop-filter: var(--glass); }
+    .panel h2 { margin: 0 0 10px; font-size: 1rem; letter-spacing: -0.01em; }
+    .panel p { margin: 4px 0 12px; color: var(--muted); }
+
+    .stack { display: flex; flex-direction: column; gap: 14px; }
+    .row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+    .row .label { color: var(--muted); font-weight: 600; font-size: 0.95rem; }
+
+    .chip-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
+    .chip { border: 1px solid var(--line); border-radius: 12px; padding: 12px; background: rgba(255, 255, 255, 0.04); cursor: pointer; transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; font-weight: 600; }
+    .chip:hover { transform: translateY(-1px); border-color: var(--brand); box-shadow: 0 12px 26px rgba(0, 0, 0, 0.08); }
+    .chip.active { border-color: var(--brand); color: var(--brand); background: rgba(124, 231, 255, 0.08); }
+
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
+    .stat { padding: 12px; border-radius: 12px; border: 1px solid var(--line); background: rgba(255, 255, 255, 0.03); }
+    .stat .hint { color: var(--muted); font-size: 0.85rem; }
+    .stat .value { font-weight: 700; font-size: 1.1rem; margin-top: 6px; }
+
+    .ghost-btn { border: 1px solid var(--line); background: transparent; color: var(--text); padding: 10px 14px; border-radius: 12px; font-weight: 600; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; transition: all 0.2s ease; }
+    .ghost-btn:hover { border-color: var(--brand); color: var(--brand); }
+
+    .chat { position: relative; min-height: 70vh; display: grid; grid-template-rows: 1fr auto; border: 1px solid var(--line); border-radius: 16px; backdrop-filter: var(--glass); background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)); box-shadow: var(--shadow); }
+    .stream { overflow: auto; padding: 18px; display: flex; flex-direction: column; gap: 14px; scroll-behavior: smooth; }
+    .msg { padding: 14px 16px; border-radius: 12px; border: 1px solid var(--line); background: rgba(255,255,255,0.05); position: relative; overflow: hidden; }
+    .msg.user { border-color: rgba(124, 231, 255, 0.4); background: rgba(124, 231, 255, 0.08); align-self: flex-end; }
+    .msg.bot { border-color: rgba(217, 107, 255, 0.4); background: rgba(217, 107, 255, 0.08); }
+    .msg h3 { margin: 0 0 6px; font-size: 0.95rem; display: inline-flex; gap: 10px; align-items: center; }
+    .msg p { margin: 0; color: var(--text); line-height: 1.6; }
+    .msg .small { color: var(--muted); font-size: 0.85rem; margin-top: 8px; display: flex; align-items: center; gap: 10px; }
+    .msg .actions { position: absolute; right: 10px; top: 10px; display: flex; gap: 6px; opacity: 0; transition: opacity 0.2s ease; }
+    .msg:hover .actions { opacity: 1; }
+    .icon { width: 18px; height: 18px; }
+    .action-btn { width: 32px; height: 32px; border-radius: 8px; border: 1px solid var(--line); background: rgba(255,255,255,0.05); color: var(--text); cursor: pointer; display: grid; place-items: center; }
+
+    .composer { padding: 14px; border-top: 1px solid var(--line); display: grid; grid-template-columns: auto 1fr auto; gap: 12px; align-items: center; background: rgba(255,255,255,0.02); }
+    .input { width: 100%; border-radius: 12px; border: 1px solid var(--line); padding: 12px 14px; background: rgba(255,255,255,0.07); color: var(--text); font-size: 1rem; }
+    .input:focus { outline: 2px solid rgba(124, 231, 255, 0.45); }
+    .cta { border: none; border-radius: 12px; padding: 12px 18px; font-weight: 700; letter-spacing: 0.01em; background: var(--accent); color: #0b1021; cursor: pointer; box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18); }
+
+    .quick { display: flex; gap: 8px; flex-wrap: wrap; }
+    .quick button { border: 1px solid var(--line); background: rgba(255,255,255,0.04); color: var(--text); border-radius: 10px; padding: 8px 12px; cursor: pointer; font-weight: 600; }
+    .quick button:hover { border-color: var(--brand); color: var(--brand); }
+
+    .statusbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 12px; border-radius: 12px; border: 1px solid var(--line); background: rgba(255, 255, 255, 0.03); }
+    .pulse { width: 10px; height: 10px; border-radius: 50%; background: var(--success); box-shadow: 0 0 0 rgba(109, 216, 163, 0.6); animation: pulse 2s infinite; }
+    @keyframes pulse { 0% { box-shadow: 0 0 0 0 rgba(109, 216, 163, 0.6); } 70% { box-shadow: 0 0 0 12px rgba(109, 216, 163, 0); } 100% { box-shadow: 0 0 0 0 rgba(109, 216, 163, 0); } }
+
+    .timeline { display: flex; align-items: center; gap: 6px; color: var(--muted); font-size: 0.9rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--brand); }
+
+    .floating { position: fixed; right: 22px; bottom: 22px; display: grid; gap: 10px; }
+    .fab { width: 56px; height: 56px; border-radius: 50%; background: var(--accent); border: none; color: #0b1021; font-size: 1.1rem; font-weight: 700; box-shadow: var(--shadow); cursor: pointer; }
+    .fab.secondary { background: rgba(255,255,255,0.1); border: 1px solid var(--line); color: var(--text); }
+
+    .notice { margin-top: 10px; padding: 10px 12px; border-radius: 12px; border: 1px dashed var(--line); color: var(--muted); font-size: 0.9rem; }
+
+    @media (max-width: 1100px) {
+      main { grid-template-columns: 1fr; }
+      header { position: static; }
+    }
+    @media (max-width: 720px) {
+      .composer { grid-template-columns: 1fr; }
+      .frame { padding: 20px 16px 30px; }
+      .panel { padding: 16px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <header>
+      <div class="logo">LN</div>
+      <div style="flex:1">
+        <div class="title">Linda Nova</div>
+        <div class="timeline"><span class="dot"></span><span>Fluides Bot-Interface, optimiert für schnellen Kontextwechsel.</span></div>
+      </div>
+      <div class="pill" id="theme-pill">🌙 <small>Dark</small></div>
+      <div class="pill" id="sync-pill">🔄 <small>Live</small></div>
+      <span class="badge">Beta · Motion UI</span>
+    </header>
+
+    <main>
+      <section class="stack">
+        <div class="panel">
+          <div class="row">
+            <h2>Control Center</h2>
+            <button class="ghost-btn" id="reset">Reset</button>
+          </div>
+          <p>Wähle einen Fokus und starte schneller. Änderungen wirken sofort auf die nächste Antwort.</p>
+          <div class="chip-grid" id="domains">
+            <div class="chip active" data-domain="Standard">Standard · Neugierig</div>
+            <div class="chip" data-domain="AEVO">AEVO · Prüfungsfit</div>
+            <div class="chip" data-domain="Recht">Recht · Quellenfokus</div>
+            <div class="chip" data-domain="Kommunikation">Kommunikation · Klar & dialogisch</div>
+            <div class="chip" data-domain="Personal">Personal · Praxisnah</div>
+            <div class="chip" data-domain="VWL">VWL · Kompakt</div>
+          </div>
+          <div class="notice">Tipp: Snippets per Klick einfügen, dann mit Enter senden.</div>
+          <div class="quick" id="quick-prompts"></div>
+        </div>
+
+        <div class="panel">
+          <h2>Live-Puls</h2>
+          <div class="statusbar">
+            <div style="display:flex;align-items:center;gap:10px">
+              <div class="pulse"></div>
+              <div>
+                <div class="label">Session-Ton</div>
+                <div style="color:var(--muted);font-size:0.9rem" id="status">Aktiv · vorbereitet</div>
+              </div>
+            </div>
+            <div style="display:flex;gap:8px">
+              <button class="ghost-btn" id="copy-context">📋 Kontext</button>
+              <button class="ghost-btn" id="toggle-gender">⚧ neutral</button>
+            </div>
+          </div>
+          <div class="grid" style="margin-top:14px">
+            <div class="stat">
+              <div class="hint">Modus</div>
+              <div class="value" id="stat-domain">Standard</div>
+            </div>
+            <div class="stat">
+              <div class="hint">Gespräche</div>
+              <div class="value" id="stat-count">0</div>
+            </div>
+            <div class="stat">
+              <div class="hint">Letzte Aktivität</div>
+              <div class="value" id="stat-last">–</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="chat">
+        <div class="stream" id="stream"></div>
+        <div class="composer">
+          <div class="quick" id="inline-prompts"></div>
+          <input id="input" class="input" placeholder="Frag mich etwas …" autocomplete="off" />
+          <button class="cta" id="send">Senden →</button>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <div class="floating">
+    <button class="fab" id="theme-toggle">🌓</button>
+    <button class="fab secondary" id="privacy">ⓘ</button>
+  </div>
+
+  <template id="privacy-sheet">
+    <div class="panel" style="max-width:480px; padding:18px;">
+      <h2 style="margin:0 0 6px">Datenschutzhinweis</h2>
+      <p>Fragen werden an das Backend gesendet. Keine sensiblen Daten eingeben. Verlauf wird lokal im Browser gespeichert.</p>
+      <div style="display:flex;gap:10px;margin-top:12px">
+        <button class="cta" style="padding:10px 14px;font-size:0.95rem;">Verstanden</button>
+        <button class="ghost-btn" style="flex:1">Details</button>
+      </div>
+    </div>
+  </template>
+
+  <script>
+    const $ = (q) => document.querySelector(q);
+    const stream = $('#stream');
+    const input = $('#input');
+    const quickPrompts = $('#quick-prompts');
+    const inlinePrompts = $('#inline-prompts');
+
+    const STORAGE = 'linda.nova.v1';
+    const BOT_ENDPOINT = '/api/bot';
+    const MAX_HISTORY = 6;
+
+    const defaultState = {
+      theme: 'dark',
+      domain: 'Standard',
+      genderNeutral: true,
+      messages: [],
+    };
+
+    const loadState = () => {
+      try {
+        return { ...defaultState, ...(JSON.parse(localStorage.getItem(STORAGE)) || {}) };
+      } catch (e) {
+        return { ...defaultState };
+      }
+    };
+
+    let state = loadState();
+
+    const promptLibrary = [
+      { label: 'TL;DR', text: 'Fasse in 3 Stichpunkten zusammen.' },
+      { label: 'Story', text: 'Erfinde eine kurze Beispielgeschichte.' },
+      { label: 'Prüfung', text: 'Formuliere prüfungsnah und komprimiert.' },
+      { label: 'Checkliste', text: 'Erstelle eine 5-Punkte-Checkliste.' },
+      { label: 'Feedback', text: 'Gib konstruktives Feedback in Ich-Form.' },
+    ];
+
+    function persist() {
+      localStorage.setItem(STORAGE, JSON.stringify(state));
+    }
+
+    function setTheme(theme) {
+      state.theme = theme;
+      document.body.classList.toggle('light', theme === 'light');
+      $('#theme-pill').innerHTML = theme === 'light' ? '☀️ <small>Light</small>' : '🌙 <small>Dark</small>';
+      persist();
+    }
+
+    function renderQuick() {
+      quickPrompts.innerHTML = promptLibrary.map(p => `<button data-text="${p.text}">${p.label}</button>`).join('');
+      inlinePrompts.innerHTML = promptLibrary.slice(0, 3).map(p => `<button data-text="${p.text}">${p.label}</button>`).join('');
+      [...quickPrompts.querySelectorAll('button'), ...inlinePrompts.querySelectorAll('button')].forEach(btn => {
+        btn.onclick = () => {
+          input.value = (input.value + ' ' + btn.dataset.text).trim();
+          input.focus();
+        };
+      });
+    }
+
+    function renderDomain(domain) {
+      $('#stat-domain').textContent = domain;
+      state.domain = domain;
+      document.querySelectorAll('#domains .chip').forEach(chip => chip.classList.toggle('active', chip.dataset.domain === domain));
+      persist();
+    }
+
+    function renderStats() {
+      $('#stat-count').textContent = state.messages.length;
+      $('#stat-last').textContent = state.messages.length ? new Date(state.messages[state.messages.length - 1].ts).toLocaleTimeString() : '–';
+    }
+
+    function templateMessage(role, content, meta = '') {
+      const wrap = document.createElement('div');
+      wrap.className = `msg ${role}`;
+      wrap.innerHTML = `
+        <div class="actions">
+          <button class="action-btn" data-action="copy" title="Antwort kopieren">📋</button>
+          ${role === 'bot' ? '<button class="action-btn" data-action="replay" title="Neu senden">⟳</button>' : ''}
+        </div>
+        <h3>${role === 'bot' ? 'Linda Nova' : 'Du'} <span style="color:var(--muted);font-weight:500;">${meta}</span></h3>
+        <p>${content}</p>
+        <div class="small">${role === 'bot' ? 'Synthese + Kontext' : 'Eingabe'} · ${new Date().toLocaleTimeString()}</div>
+      `;
+
+      wrap.querySelectorAll('.action-btn').forEach(btn => {
+        btn.onclick = () => {
+          if (btn.dataset.action === 'copy') {
+            navigator.clipboard?.writeText(content);
+            btn.textContent = '✔';
+            setTimeout(() => btn.textContent = '📋', 1200);
+          }
+          if (btn.dataset.action === 'replay') {
+            const lastUser = [...state.messages].reverse().find(m => m.role === 'user');
+            input.value = lastUser ? lastUser.content : '';
+            input.focus();
+          }
+        };
+      });
+      return wrap;
+    }
+
+    function renderMessages() {
+      stream.innerHTML = '';
+      state.messages.forEach(msg => {
+        stream.appendChild(templateMessage(msg.role, msg.content, msg.meta || '')); 
+      });
+      stream.scrollTop = stream.scrollHeight;
+    }
+
+    function addMessage(role, content, meta = '') {
+      const entry = { role, content, meta, ts: Date.now() };
+      state.messages.push(entry);
+      if (state.messages.length > 50) state.messages = state.messages.slice(-50);
+      persist();
+      renderMessages();
+      renderStats();
+    }
+
+    function buildContext() {
+      const tail = state.messages.slice(-MAX_HISTORY).map(m => `${m.role === 'bot' ? 'Assistant' : 'User'}: ${m.content}`).join('\n');
+      const persona = state.genderNeutral ? 'Nutze neutrale Sprache.' : 'Sprich locker, nicht neutral.';
+      return `${persona}\nModus: ${state.domain}\n${tail}`.trim();
+    }
+
+    async function askBot(text) {
+      const fallback = () => `Ich habe "${text}" erhalten. Formuliere deine Frage gerne noch präziser – Modus: ${state.domain}.`;
+      try {
+        const res = await fetch(BOT_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: text, context: buildContext(), domain: state.domain }),
+        });
+        if (!res.ok) return fallback();
+        const body = await res.text();
+        return body?.trim() || fallback();
+      } catch (e) {
+        return fallback();
+      }
+    }
+
+    async function send() {
+      const value = input.value.trim();
+      if (!value) return;
+      input.value = '';
+      addMessage('user', value, state.domain);
+      addMessage('bot', 'Denke nach …', 'tippt');
+
+      const answer = await askBot(value);
+      state.messages[state.messages.length - 1] = { role: 'bot', content: answer, meta: state.domain, ts: Date.now() };
+      persist();
+      renderMessages();
+      renderStats();
+      $('#status').textContent = 'Antwort geliefert';
+    }
+
+    function attachEvents() {
+      $('#send').onclick = send;
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          send();
+        }
+      });
+
+      $('#theme-toggle').onclick = () => setTheme(state.theme === 'dark' ? 'light' : 'dark');
+      $('#theme-pill').onclick = () => setTheme(state.theme === 'dark' ? 'light' : 'dark');
+
+      document.querySelectorAll('#domains .chip').forEach(chip => {
+        chip.onclick = () => renderDomain(chip.dataset.domain);
+      });
+
+      $('#reset').onclick = () => {
+        state = { ...defaultState };
+        persist();
+        setTheme(state.theme);
+        renderDomain(state.domain);
+        renderMessages();
+        renderStats();
+        $('#status').textContent = 'Zurückgesetzt';
+      };
+
+      $('#toggle-gender').onclick = () => {
+        state.genderNeutral = !state.genderNeutral;
+        $('#toggle-gender').textContent = state.genderNeutral ? '⚧ neutral' : '🙂 locker';
+        persist();
+      };
+
+      $('#copy-context').onclick = () => {
+        navigator.clipboard?.writeText(buildContext());
+        $('#status').textContent = 'Kontext kopiert';
+      };
+
+      $('#privacy').onclick = () => {
+        const sheet = document.importNode($('#privacy-sheet').content, true);
+        const modal = document.createElement('div');
+        modal.style.position = 'fixed';
+        modal.style.inset = 0;
+        modal.style.display = 'grid';
+        modal.style.placeItems = 'center';
+        modal.style.background = 'rgba(0,0,0,0.55)';
+        modal.style.backdropFilter = 'blur(8px)';
+        modal.onclick = (e) => { if (e.target === modal) modal.remove(); };
+        modal.appendChild(sheet);
+        document.body.appendChild(modal);
+        modal.querySelector('.cta').onclick = () => modal.remove();
+      };
+    }
+
+    function init() {
+      setTheme(state.theme);
+      renderDomain(state.domain);
+      renderQuick();
+      renderMessages();
+      renderStats();
+      attachEvents();
+      $('#sync-pill').onclick = () => { $('#status').textContent = 'Live aktualisiert'; };
+      if (!state.messages.length) {
+        addMessage('bot', 'Hi, ich bin Linda Nova. Wähle links einen Modus und leg los.', 'ready');
+      }
+    }
+
+    init();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new Linda Nova bot page with a gradient motion-inspired layout and dual theme support
- include control center chips, quick prompt shortcuts, and live status widgets to speed up prompting
- wire chat flow to /api/bot with local history context, copy actions, and a lightweight privacy overlay

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69318d292358832495ffa08a4ab05a3a)