### PR TITLE
Add dynamic Linda trainer HTML experience

### DIFF
--- a/linda-trainer.html
+++ b/linda-trainer.html
@@ -1,0 +1,662 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Linda – Coaching Bot (Dynamic Trainer)</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <style>
+    :root {
+      --bg: #050916;
+      --panel: rgba(12, 18, 34, 0.8);
+      --panel-2: rgba(255, 255, 255, 0.08);
+      --line: rgba(255, 255, 255, 0.12);
+      --text: #e8ecf7;
+      --muted: #a8b3c7;
+      --brand: #5be7c4;
+      --brand-2: #5aa8ff;
+      --shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+      --radius: 14px;
+      --transition: all 0.25s ease;
+      --glow: 0 0 24px rgba(90, 168, 255, 0.5), 0 0 32px rgba(91, 231, 196, 0.45);
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; font-family: 'Inter', system-ui, -apple-system, sans-serif; color: var(--text); background: radial-gradient(circle at 20% 20%, rgba(91, 231, 196, 0.15), transparent 35%),
+                radial-gradient(circle at 80% 10%, rgba(90, 168, 255, 0.18), transparent 40%),
+                radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.08), transparent 35%), #050916; }
+    a { color: var(--brand-2); text-decoration: none; }
+    a:hover { color: var(--brand); }
+
+    /* Header */
+    .top { position: sticky; top: 0; z-index: 20; padding: 1rem 1.25rem; display: grid; grid-template-columns: auto 1fr auto; gap: 1.25rem; align-items: center; background: rgba(5,9,22,0.9); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); box-shadow: var(--shadow); }
+    .brand-wrap { display: flex; align-items: center; gap: 0.75rem; }
+    .brand-icon { width: 44px; height: 44px; border-radius: 12px; background: linear-gradient(135deg, rgba(90,168,255,0.8), rgba(91,231,196,0.8)); display: grid; place-items: center; font-weight: 800; color: #041126; letter-spacing: -0.05em; box-shadow: var(--glow); }
+    .brand { font-size: 1.4rem; font-weight: 700; letter-spacing: -0.01em; }
+    .pulse { display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.55rem 0.9rem; border-radius: 999px; border: 1px solid var(--line); background: var(--panel-2); color: var(--muted); font-size: 0.95rem; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.02); }
+    .pulse::before { content: ""; width: 9px; height: 9px; background: linear-gradient(135deg, var(--brand), var(--brand-2)); border-radius: 50%; box-shadow: 0 0 12px rgba(91, 231, 196, 0.7); animation: blink 1.6s ease-in-out infinite; }
+    @keyframes blink { 0%,100%{ opacity: 0.25;} 50%{opacity:1;} }
+    .top-actions { display: flex; align-items: center; gap: 0.75rem; justify-content: flex-end; }
+    .icon-btn { appearance: none; border: 1px solid var(--line); background: var(--panel-2); color: var(--text); border-radius: 12px; padding: 0.65rem; cursor: pointer; transition: var(--transition); display: grid; place-items: center; }
+    .icon-btn:hover { border-color: var(--brand); box-shadow: var(--glow); transform: translateY(-1px); }
+    .badge { display: inline-flex; align-items: center; gap: 0.4rem; background: var(--panel-2); border: 1px solid var(--line); padding: 0.55rem 0.9rem; border-radius: 999px; font-weight: 600; color: var(--brand); }
+
+    /* Layout */
+    .container { display: grid; grid-template-columns: 320px 1fr; gap: 1.5rem; padding: 1.5rem; max-width: 1500px; margin: 0 auto; min-height: calc(100vh - 72px); }
+    .sidebar { display: flex; flex-direction: column; gap: 1rem; }
+    .panel { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); position: relative; overflow: hidden; }
+    .panel::before { content: ""; position: absolute; inset: 0; background: linear-gradient(145deg, rgba(90,168,255,0.07), rgba(91,231,196,0.05)); opacity: 0.9; pointer-events: none; }
+
+    .coach { padding: 1.5rem; display: flex; gap: 1rem; align-items: center; position: relative; z-index: 1; }
+    .coach img { width: 88px; height: 88px; object-fit: cover; border-radius: 16px; border: 2px solid var(--line); box-shadow: var(--glow); }
+    .coach h2 { font-size: 1.15rem; letter-spacing: -0.01em; }
+    .coach p { color: var(--muted); margin-top: 0.35rem; font-size: 0.95rem; }
+    .tag { display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.4rem 0.7rem; border-radius: 10px; background: var(--panel-2); border: 1px solid var(--line); color: var(--text); font-weight: 600; font-size: 0.85rem; }
+
+    .quick { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 0.65rem; padding: 1rem; position: relative; z-index: 1; }
+    .chip { background: var(--panel-2); border: 1px solid var(--line); border-radius: 12px; padding: 0.7rem 0.9rem; font-weight: 600; cursor: pointer; transition: var(--transition); color: var(--text); text-align: center; }
+    .chip:hover { transform: translateY(-2px); border-color: var(--brand); box-shadow: var(--glow); }
+
+    /* Sessions */
+    .sessions { position: relative; z-index: 1; }
+    .sessions .head { display: flex; align-items: center; justify-content: space-between; padding: 1.1rem 1.25rem; border-bottom: 1px solid var(--line); }
+    .sessions .list { max-height: 60vh; overflow: auto; padding: 0.75rem 1rem 1.1rem; display: grid; gap: 0.75rem; }
+    .sess { border: 1px solid var(--line); border-radius: 12px; padding: 0.85rem 0.95rem; background: var(--panel-2); cursor: pointer; transition: var(--transition); }
+    .sess:hover { transform: translateY(-1px); border-color: var(--brand); box-shadow: var(--glow); }
+    .sess.active { border-color: var(--brand); box-shadow: var(--glow); }
+    .sess .ttl { font-weight: 600; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
+    .sess small { color: var(--muted); font-size: 0.85rem; }
+    .sess .rowbtns { display: flex; gap: 0.4rem; margin-top: 0.5rem; }
+    .sm-btn { appearance: none; border: 1px solid var(--line); background: transparent; color: var(--text); border-radius: 10px; padding: 0.35rem 0.65rem; cursor: pointer; transition: var(--transition); font-size: 0.85rem; }
+    .sm-btn:hover { border-color: var(--brand); color: var(--brand); }
+
+    /* Chat */
+    .chat { position: relative; display: flex; flex-direction: column; gap: 1rem; }
+    .hero { background: linear-gradient(120deg, rgba(90,168,255,0.28), rgba(91,231,196,0.22)); border: 1px solid rgba(255,255,255,0.15); border-radius: var(--radius); padding: 1.2rem 1.5rem; box-shadow: var(--glow); display: grid; grid-template-columns: 1fr auto; gap: 1rem; align-items: center; }
+    .hero h1 { font-size: 1.3rem; letter-spacing: -0.01em; }
+    .hero p { color: #f4f8ff; opacity: 0.9; }
+    .hero .stats { display: flex; gap: 0.75rem; }
+    .stat { background: rgba(5,9,22,0.35); border: 1px solid rgba(255,255,255,0.15); border-radius: 12px; padding: 0.75rem 1rem; text-align: center; }
+    .stat .label { color: var(--muted); font-size: 0.85rem; }
+    .stat .val { font-weight: 700; font-size: 1.1rem; }
+
+    .log { flex: 1; overflow: auto; display: flex; flex-direction: column; gap: 1rem; padding: 0.25rem 0.5rem 0.5rem; }
+    .bubble { max-width: 82ch; border-radius: 16px; padding: 1.25rem 1.35rem; background: rgba(12, 18, 34, 0.7); border: 1px solid var(--line); box-shadow: var(--shadow); line-height: 1.7; position: relative; }
+    .bubble.me { align-self: flex-end; background: linear-gradient(135deg, rgba(91,231,196,0.2), rgba(90,168,255,0.2)); border-color: rgba(91,231,196,0.4); box-shadow: var(--glow); }
+    .bubble .md h1, .bubble .md h2, .bubble .md h3 { margin: 0.5rem 0 0.8rem; color: var(--brand); }
+    .bubble .md p, .bubble .md ul, .bubble .md ol, .bubble .md pre { margin: 0.65rem 0; }
+    .bubble .md pre { background: rgba(255,255,255,0.04); border-radius: 10px; padding: 0.8rem; overflow-x: auto; }
+    .bubble .md code { background: rgba(255,255,255,0.05); padding: 0.25rem 0.45rem; border-radius: 8px; }
+    .bubble-header { display: flex; justify-content: flex-end; margin-bottom: 0.4rem; }
+    .copy-btn { appearance: none; border: 1px solid var(--line); background: rgba(255,255,255,0.05); color: var(--muted); border-radius: 999px; padding: 0.3rem 0.65rem; cursor: pointer; display: inline-flex; align-items: center; gap: 0.4rem; transition: var(--transition); }
+    .copy-btn:hover { border-color: var(--brand); color: var(--brand); }
+    .footnotes { margin-top: 1rem; padding-top: 0.6rem; border-top: 1px solid var(--line); color: var(--muted); font-size: 0.9rem; }
+    .footnotes ol { margin-left: 1.1rem; }
+    .footnote-marker { color: var(--brand); font-size: 0.75em; vertical-align: super; }
+
+    .palette { position: absolute; bottom: 92px; left: 0; width: min(540px, 100%); background: var(--panel); border: 1px solid var(--line); border-radius: 14px; box-shadow: var(--shadow); display: none; z-index: 10; overflow: hidden; }
+    .pal-item { padding: 0.9rem 1rem; border-bottom: 1px solid var(--line); cursor: pointer; display: flex; justify-content: space-between; gap: 0.75rem; transition: var(--transition); }
+    .pal-item:hover { background: rgba(255,255,255,0.05); }
+    .pal-tag { color: var(--muted); font-size: 0.9rem; }
+
+    .composer { position: sticky; bottom: 0; background: rgba(5,9,22,0.9); border: 1px solid var(--line); border-radius: 16px; padding: 0.9rem; display: flex; gap: 0.75rem; align-items: center; box-shadow: var(--shadow); backdrop-filter: blur(8px); }
+    .in { flex: 1; border: 1px solid var(--line); border-radius: 12px; background: rgba(255,255,255,0.04); color: var(--text); padding: 0.95rem 1.1rem; font-size: 1rem; outline: none; transition: var(--transition); }
+    .in:focus { border-color: var(--brand); box-shadow: var(--glow); }
+    .send { appearance: none; border: none; background: linear-gradient(135deg, var(--brand-2), var(--brand)); color: #041126; font-weight: 800; padding: 0.95rem 1.35rem; border-radius: 12px; cursor: pointer; transition: var(--transition); letter-spacing: 0.01em; }
+    .send:hover { transform: translateY(-1px); box-shadow: var(--glow); }
+    .send:disabled { opacity: 0.65; cursor: not-allowed; }
+
+    .footer { text-align: center; padding: 1.2rem; color: var(--muted); border-top: 1px solid var(--line); margin-top: 1rem; background: rgba(5,9,22,0.9); }
+
+    /* Modals */
+    .modal { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; background: rgba(0,0,0,0.6); backdrop-filter: blur(8px); z-index: 1000; }
+    .card { background: #0c1222; color: var(--text); border: 1px solid var(--line); border-radius: 16px; box-shadow: var(--shadow); width: min(95vw, 820px); max-height: 90vh; overflow: auto; }
+    .card-h { padding: 1.25rem 1.5rem; border-bottom: 1px solid var(--line); font-weight: 700; font-size: 1.1rem; color: var(--brand); }
+    .card-b { padding: 1.5rem; line-height: 1.6; }
+    .card-f { padding: 1.25rem 1.5rem; border-top: 1px solid var(--line); display: flex; gap: 0.75rem; justify-content: flex-end; }
+    .btn { appearance: none; border: 1px solid var(--line); background: rgba(255,255,255,0.04); color: var(--text); border-radius: 12px; padding: 0.65rem 1.15rem; font-weight: 700; cursor: pointer; transition: var(--transition); }
+    .btn.primary { background: linear-gradient(135deg, var(--brand-2), var(--brand)); color: #041126; border: none; }
+    .btn:hover { border-color: var(--brand); box-shadow: var(--glow); }
+    .group { padding: 1.5rem; border-top: 1px solid var(--line); }
+    .group:first-child { border-top: none; }
+    .row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin: 0.75rem 0; }
+    .select, .ta, .in-inline { width: 100%; border: 1px solid var(--line); border-radius: 12px; background: rgba(255,255,255,0.04); color: var(--text); padding: 0.85rem 1rem; }
+    .switch { width: 54px; height: 30px; border-radius: 16px; border: 1px solid var(--line); background: rgba(255,255,255,0.05); position: relative; cursor: pointer; transition: var(--transition); }
+    .switch > i { position: absolute; width: 24px; height: 24px; top: 2px; left: 2px; border-radius: 12px; background: #fff; transition: var(--transition); }
+    .switch.on { background: linear-gradient(135deg, var(--brand-2), var(--brand)); border: none; }
+    .switch.on > i { left: 28px; }
+
+    @media (max-width: 1100px) {
+      .container { grid-template-columns: 1fr; }
+      .log { padding: 0.5rem 0; }
+    }
+    @media (max-width: 720px) {
+      .top { grid-template-columns: 1fr; justify-items: flex-start; }
+      .hero { grid-template-columns: 1fr; }
+      .composer { flex-direction: column; }
+      .send { width: 100%; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- Datenschutzhinweis -->
+<div id="m-privacy" class="modal" style="display:flex">
+  <div class="card">
+    <div class="card-h">Datenschutzhinweis</div>
+    <div class="card-b">
+      <p>Um diesen Chatbot nutzen zu können, ist deine Zustimmung zur Datenschutzerklärung erforderlich:</p>
+      <ul style="margin:1rem 0 0 1.5rem">
+        <li>Deine Eingaben werden an OpenAI (USA) und Make (EU) übermittelt.</li>
+        <li>Die übermittelten Daten werden zur Generierung von Antworten verarbeitet.</li>
+        <li>Bitte gib <strong>keine sensiblen oder personenbezogenen Daten</strong> ein!</li>
+        <li>Weitere Informationen: <a href="https://openai.com/policies/privacy-policy" target="_blank" rel="noopener">OpenAI</a>, <a href="https://www.make.com/en/privacy-policy" target="_blank" rel="noopener">Make.com</a>.</li>
+      </ul>
+      <p class="muted" style="margin-top:1rem">Hinweis: Dein <b>Chatverlauf</b> und deine <b>Snippets</b> werden <b>nur lokal</b> auf deinem Gerät gespeichert (localStorage). Du kannst beides in den Einstellungen verwalten (löschen/exportieren).</p>
+    </div>
+    <div class="card-f">
+      <button class="btn" id="p-decline">Ablehnen</button>
+      <button class="btn primary" id="p-accept">Zustimmen</button>
+    </div>
+  </div>
+</div>
+
+<!-- Nutzungshinweise -->
+<div id="m-usage" class="modal">
+  <div class="card">
+    <div class="card-h">Wichtige Hinweise zur Bot-Nutzung</div>
+    <div class="card-b">
+      <ul style="margin:1rem 0 0 1.5rem">
+        <li><strong>Automatisierte Antworten:</strong> Alle Antworten werden von KI generiert.</li>
+        <li><strong>Keine Gewähr:</strong> Inhalte können unvollständig/fehlerhaft sein – bitte prüfen.</li>
+        <li><strong>Kein Ersatz für Beratung:</strong> Keine Rechts-, Medizin-, Steuer- oder Finanzberatung.</li>
+        <li><strong>Eigenverantwortung:</strong> Antworten kritisch hinterfragen und Quellen beachten.</li>
+      </ul>
+    </div>
+    <div class="card-f"><button class="btn primary" id="u-accept">Einverstanden</button></div>
+  </div>
+</div>
+
+<!-- Einstellungen -->
+<div id="m-settings" class="modal">
+  <div class="card">
+    <div class="card-h">Einstellungen</div>
+
+    <div class="group">
+      <div class="row">
+        <label>Darstellung</label>
+        <div class="chips" id="chip-theme">
+          <div class="chip" data-val="light">Hell</div>
+          <div class="chip" data-val="dark">Dunkel</div>
+          <div class="chip" data-val="system">System</div>
+        </div>
+      </div>
+      <div class="row"><label>Gender-Sprache</label><div id="sw-gender" class="switch"><i></i></div></div>
+      <div class="row"><label>Begrüßung anzeigen</label><div id="sw-greet" class="switch on"><i></i></div></div>
+      <div class="row"><label>Lernmodus (inaktiv)</label><div class="switch" style="opacity:0.5;pointer-events:none"><i></i></div></div>
+    </div>
+
+    <div class="group">
+      <div class="row">
+        <label>Fachmodus</label>
+        <select id="sel-domain" class="select">
+          <option value="">— Kein spezieller Modus —</option>
+          <option value="AEVO">AEVO</option>
+          <option value="Personal">Personal</option>
+          <option value="Recht">Recht</option>
+          <option value="Kommunikation">Kommunikation</option>
+          <option value="VWL">VWL</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="group">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem">
+        <div><strong>Prompt-Snippets</strong> <span class="muted">(per „/alias“ einfügen)</span></div>
+        <div>
+          <button class="btn" id="pm-add">Neu</button>
+          <button class="btn" id="pm-export">Export</button>
+          <button class="btn" id="pm-import">Import</button>
+        </div>
+      </div>
+      <div id="pm-list" style="display:grid;grid-template-columns:repeat(auto-fit, minmax(280px, 1fr));gap:0.8rem"></div>
+    </div>
+
+    <div class="group">
+      <div class="row" style="align-items:flex-start">
+        <div>
+          <div><strong>Chatverlauf</strong></div>
+          <div class="muted">Nur lokal gespeichert. Du kannst ihn löschen oder exportieren.</div>
+        </div>
+        <div style="display:flex;gap:0.75rem">
+          <button class="btn" id="btn-export-all">Gesamt-Export (.txt)</button>
+          <button class="btn" id="btn-clear-all">Alle löschen</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="card-f">
+      <button class="btn" id="s-close">Schließen</button>
+      <button class="btn primary" id="s-save">Speichern</button>
+    </div>
+  </div>
+</div>
+
+<!-- Prompt-Editor -->
+<div id="m-prompt" class="modal">
+  <div class="card">
+    <div class="card-h">Snippet</div>
+    <div class="card-b">
+      <div class="row"><label style="min-width:140px">Titel</label><input id="pe-title" class="in-inline" /></div>
+      <div class="row"><label style="min-width:140px">Alias</label><input id="pe-alias" class="in-inline" placeholder="/aevo" /></div>
+      <div style="margin:0.6rem 0 0.35rem">Text</div>
+      <textarea id="pe-content" class="ta" placeholder="Dieser Text wird bei /alias eingefügt."></textarea>
+    </div>
+    <div class="card-f">
+      <button class="btn" id="pe-cancel">Abbrechen</button>
+      <button class="btn primary" id="pe-save">Speichern</button>
+    </div>
+  </div>
+</div>
+
+<!-- App -->
+<div class="top">
+  <div class="brand-wrap">
+    <div class="brand-icon">LT</div>
+    <div>
+      <div class="brand">Linda Trainer</div>
+      <div class="pulse">Coach-Session aktiv</div>
+    </div>
+  </div>
+  <div class="badge" id="domain-badge" style="display:none">📘 Fachmodus: —</div>
+  <div class="top-actions">
+    <button class="icon-btn" id="btn-settings" aria-label="Einstellungen öffnen">⚙️</button>
+  </div>
+</div>
+
+<div class="container">
+  <aside class="sidebar">
+    <div class="panel coach">
+      <img src="https://ntc-bot1.netlify.app/Bildschirmfoto%202025-06-26%20um%2021.09.25.png" alt="Linda" />
+      <div>
+        <h2>Coach Linda</h2>
+        <p>Trainingsimpulse, klare Struktur, schnelle Snippets. Ideal für AEVO & Prüfungen.</p>
+        <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-top:0.4rem">
+          <span class="tag">⚡ Fokus</span>
+          <span class="tag">🧭 Guideline</span>
+          <span class="tag">🛠️ Praxis</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="quick">
+        <div class="chip" data-quick="/tldr">TL;DR</div>
+        <div class="chip" data-quick="/aevo">AEVO</div>
+        <div class="chip" data-quick="/struktur">Struktur</div>
+        <div class="chip" data-quick="/feedback">Feedback</div>
+      </div>
+    </div>
+
+    <div class="panel sessions">
+      <div class="head">
+        <div style="font-weight:700">Verläufe</div>
+        <button id="btn-new" class="sm-btn">Neu</button>
+      </div>
+      <div id="sess-list" class="list"></div>
+    </div>
+  </aside>
+
+  <section class="chat">
+    <div class="hero">
+      <div>
+        <h1>Trainiere Antworten mit Struktur & Tempo</h1>
+        <p>Nutze Snippets über "/", verwende den Fachmodus und kopiere Antworten direkt. Die letzten 3 Nachrichten bleiben als Kontext.</p>
+      </div>
+      <div class="stats">
+        <div class="stat"><div class="label">Kontext</div><div class="val">3 Turns</div></div>
+        <div class="stat"><div class="label">Snippets</div><div class="val" id="stat-snippets">–</div></div>
+      </div>
+    </div>
+
+    <div id="log" class="log"></div>
+    <div style="position:relative">
+      <div id="palette" class="palette"></div>
+      <div class="composer">
+        <input id="in" class="in" placeholder="Deine Frage… (Tipp „/“ für Snippets)" />
+        <button id="send" class="send">Senden</button>
+      </div>
+    </div>
+  </section>
+</div>
+
+<div class="footer">
+  <p>&copy; 2025 Linda Coach. Dynamic Training Experience.</p>
+</div>
+
+<!-- Kontext-Add-on (unverändert) -->
+<script id="linda-context-addon">
+(function(){
+  if (localStorage.getItem('linda.addon.disabled') === '1') { console.info('[linda-addon] disabled'); return; }
+  const MAX_CONTEXT_CHARS = 2500;
+  const HISTORY_TURNS = 3;
+  function getFachmodus() {
+    const sel = document.getElementById('sel-domain');
+    if (sel && sel.value) return sel.value;
+    const selects = Array.from(document.querySelectorAll("select"));
+    const candidate = selects.find(s => /AEVO|Personal|Recht|VWL|Kommunikation/i.test(s.textContent || ""));
+    const val = candidate?.value?.trim();
+    return val && val.length ? val : "Personal";
+  }
+  function buildCompressedContext() {
+    let historyArr = [];
+    try {
+      const raw = localStorage.getItem("chatHistory");
+      if (raw) historyArr = JSON.parse(raw) || [];
+    } catch {}
+    if (!historyArr || !historyArr.length) {
+      try {
+        const rawSessions = localStorage.getItem('linda.sessions');
+        const activeId = localStorage.getItem('linda.activeId');
+        const sessions = rawSessions ? JSON.parse(rawSessions) : [];
+        let session = null;
+        if (activeId) session = sessions.find(s=>s.id===activeId);
+        if (!session && sessions && sessions.length) session = sessions[sessions.length-1];
+        if (session && Array.isArray(session.messages)) {
+          const turns = [];
+          let pendingUser = null;
+          for (const m of session.messages) {
+            if (m.role === 'user') {
+              pendingUser = (pendingUser ? (pendingUser + ' ' + m.content) : m.content) || '';
+            } else if (m.role === 'assistant') {
+              if (pendingUser !== null) {
+                turns.push({ user: pendingUser, bot: m.content || '' });
+                pendingUser = null;
+              }
+            }
+          }
+          if (pendingUser !== null) turns.push({ user: pendingUser, bot: '' });
+          historyArr = turns.map(t => ({ user: t.user, bot: t.bot }));
+        }
+      } catch {}
+    }
+    const last = historyArr.slice(-HISTORY_TURNS);
+    let context = last.map(turn => `User: ${turn.user || ''}\nLinda: ${turn.bot || ''}`).join("\n");
+    if (context.length > MAX_CONTEXT_CHARS) {
+      context = "Kurzzusammenfassung vorheriger Dialoge:\n" + context.slice(-MAX_CONTEXT_CHARS);
+    }
+    return context;
+  }
+  const _origFetch = window.fetch.bind(window);
+  window.fetch = async function(url, options = {}) {
+    try {
+      const method = ((options && options.method) || "GET").toUpperCase();
+      const isPost = method === "POST";
+      const headers = options && options.headers ? options.headers : {};
+      const contentType = (headers["Content-Type"] || headers["content-type"] || "").toLowerCase();
+      const isJson = contentType.includes("application/json") || (typeof options.body === "string" && options.body.trim().startsWith("{"));
+      if (isPost && isJson && typeof options.body === "string") {
+        try {
+          const body = JSON.parse(options.body);
+          const hasMessageLike = (typeof body.message === "string") || (typeof body.question === "string");
+          if (body && typeof body === "object" && hasMessageLike && !("context" in body) && localStorage.getItem('linda.addon.disabled') !== '1') {
+            const context = buildCompressedContext();
+            const fachmodus = getFachmodus();
+            const augmented = { ...body, context, fachmodus, user: body.user || "Dozent" };
+            options.body = JSON.stringify(augmented);
+            console.info('[linda-addon] augmented fetch ->', url, { fachmodus, contextAdded: !!context, originalHasQuestion: !!body.question, originalHasMessage: !!body.message });
+          }
+        } catch (err) {
+          console.warn('[linda-addon] could not parse JSON body, skipping augmentation', err);
+        }
+      }
+    } catch (err) {
+      console.warn('[linda-addon] wrapper error, calling original fetch', err);
+    }
+    return _origFetch(url, options);
+  };
+  function attachInputHook() {
+    const buttons = Array.from(document.querySelectorAll("button"));
+    const sendBtn = buttons.find(b => (b.innerText || b.textContent || "").trim().toLowerCase() === "senden" || (b.getAttribute('id') === 'send'));
+    const inputs  = Array.from(document.querySelectorAll("input[type='text'], textarea, input:not([type])"));
+    const userInput = inputs[0];
+    if (!sendBtn || !userInput) return;
+    const handler = () => {
+      const text = (userInput.value || "").trim();
+      if (!text) return;
+      try {
+        const hist = JSON.parse(localStorage.getItem("chatHistory")) || [];
+        hist.push({ user: text, bot: "" });
+        localStorage.setItem("chatHistory", JSON.stringify(hist));
+      } catch {}
+    };
+    if (!sendBtn.__lindaHooked) {
+      sendBtn.addEventListener("click", handler, { capture: true });
+      if (userInput && !userInput.__lindaHooked) {
+        userInput.addEventListener("keydown", (e) => { if (e.key === "Enter" && !e.shiftKey) handler(); }, { capture: true });
+        userInput.__lindaHooked = true;
+      }
+      sendBtn.__lindaHooked = true;
+    }
+  }
+  if (document.readyState === "loading") { document.addEventListener("DOMContentLoaded", attachInputHook); }
+  else { attachInputHook(); }
+})();
+</script>
+
+<script>
+(function(){
+  // Anti-Duplication
+  document.addEventListener('contextmenu', e => e.preventDefault());
+  document.addEventListener('copy', e => e.preventDefault());
+  document.addEventListener('cut', e => e.preventDefault());
+  document.addEventListener('paste', e => e.preventDefault());
+  document.addEventListener('selectstart', e => e.preventDefault());
+
+  const uniqueToken = 'Linda-v27.6-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
+  console.log('Unique Session Token:', uniqueToken);
+
+  const $=id=>document.getElementById(id);
+  const LS={get(k,d){try{return JSON.parse(localStorage.getItem(k))??d}catch{return d}},set(k,v){localStorage.setItem(k,JSON.stringify(v))},del(k){localStorage.removeItem(k)}};
+  const nowStr=()=>new Date().toLocaleString();
+
+  const S=LS.get('linda.settings',{theme:'light',gender:false,greet:true,domain:''});
+  let SN=LS.get('linda.snippets',[
+    {id:'s1',title:'AEVO-Kurz',alias:'/aevo',content:'Bitte juristisch sauber und prüfungsrelevant zur AEVO antworten.'},
+    {id:'s2',title:'TL;DR',alias:'/tldr',content:'TL;DR in drei Bulletpoints, je max. 12 Wörter.'}
+  ]);
+  let Sessions=LS.get('linda.sessions',[]);
+  let activeId=LS.get('linda.activeId',null);
+
+  const md=(txt)=>{try{return marked.parse(txt)}catch{return txt}};
+  const show=m=>m.style.display='flex', hide=m=>m.style.display='none';
+  const uid=()=> 's_'+Date.now().toString(36)+Math.random().toString(36).slice(2,6);
+  function saveAll(){ LS.set('linda.settings',S); LS.set('linda.snippets',SN); LS.set('linda.sessions',Sessions); LS.set('linda.activeId',activeId); updateStats(); }
+
+  function updateStats(){ const el=$('stat-snippets'); if(el) el.textContent = SN.length; }
+
+  function applyTheme(){
+    if(S.theme==='system'){
+      const m=window.matchMedia('(prefers-color-scheme: dark)');
+      document.body.classList.toggle('dark',m.matches);
+      m.onchange=()=>document.body.classList.toggle('dark',m.matches);
+    }else{
+      document.body.classList.toggle('dark',S.theme==='dark');
+    }
+    document.querySelectorAll('#chip-theme .chip').forEach(c=>c.classList.toggle('active',c.dataset.val===S.theme));
+  }
+
+  function ensureFirstSession(){
+    if(!Sessions.length){
+      const id=uid();
+      Sessions=[{id,name:'Neuer Chat',ts:Date.now(),messages:[]}];
+      activeId=id; Sessions[0].id=id; saveAll();
+    }
+    if(!activeId || !Sessions.find(s=>s.id===activeId)){ activeId=Sessions[0].id; saveAll(); }
+  }
+  function active(){ return Sessions.find(s=>s.id===activeId); }
+  function setActive(id){ activeId=id; saveAll(); renderSessions(); renderChat(); }
+  function addSession(){ const id=uid(); Sessions.unshift({id,name:'Neuer Chat',ts:Date.now(),messages:[]}); setActive(id); }
+  function renameSession(id){ const s=Sessions.find(x=>x.id===id); if(!s) return; const nn=prompt('Neuer Name für Verlauf:', s.name||''); if(nn!==null){ s.name=nn.trim()||s.name; saveAll(); renderSessions(); }}
+  function deleteSession(id){ if(!confirm('Diesen Verlauf wirklich löschen?')) return; Sessions=Sessions.filter(x=>x.id!==id); if(!Sessions.length){ addSession(); } else if(activeId===id){ activeId=Sessions[0].id; } saveAll(); renderSessions(); renderChat(); }
+  function exportSession(id){ const s=Sessions.find(x=>x.id===id); if(!s) return; const text=s.messages.map(m=>(m.role==='user'?'Du: ':'Linda: ')+m.content).join('\n\n'); const blob=new Blob([text],{type:'text/plain'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download=(s.name||'linda_chat')+'.txt'; a.click(); URL.revokeObjectURL(a.href); }
+
+  function renderSessions(){
+    const el=$('sess-list');
+    el.innerHTML = Sessions.map(s=>`
+      <div class="sess ${s.id===activeId?'active':''}" data-id="${s.id}">
+        <div class="ttl"><span>${s.name||'Chat'}</span><small>${new Date(s.ts).toLocaleDateString()}</small></div>
+        <div class="rowbtns">
+          <button class="sm-btn s-rename" title="Umbenennen">✎</button>
+          <button class="sm-btn s-export" title="Exportieren">⤓</button>
+          <button class="sm-btn s-del" title="Löschen">🗑</button>
+        </div>
+      </div>
+    `).join('');
+    el.querySelectorAll('.sess').forEach(n=>n.onclick=(e)=>{ if(e.target.closest('.rowbtns')) return; setActive(n.dataset.id); });
+    el.querySelectorAll('.s-rename').forEach(b=>b.onclick=(e)=>{e.stopPropagation(); renameSession(b.closest('.sess').dataset.id);});
+    el.querySelectorAll('.s-export').forEach(b=>b.onclick=(e)=>{e.stopPropagation(); exportSession(b.closest('.sess').dataset.id);});
+    el.querySelectorAll('.s-del').forEach(b=>b.onclick=(e)=>{e.stopPropagation(); deleteSession(b.closest('.sess').dataset.id);});
+  }
+
+  function enhanceFootnotes(bubbleEl) {
+    const mdEl = bubbleEl.querySelector('.md');
+    if (!mdEl) return;
+    const sections = mdEl.querySelectorAll('h1, h2, h3');
+    if (!sections.length) return;
+    let idx = 1;
+    const footnotes = document.createElement('div'); footnotes.className = 'footnotes';
+    const list = document.createElement('ol');
+    sections.forEach(sec => {
+      const marker = document.createElement('sup'); marker.className = 'footnote-marker'; marker.textContent = '[' + idx + ']';
+      sec.appendChild(document.createTextNode(' ')); sec.appendChild(marker);
+      const li = document.createElement('li'); li.textContent = 'Abschnitt ' + idx + ': ' + (sec.textContent || '').replace(/\[\d+\]\s*$/, '').trim();
+      list.appendChild(li); idx++;
+    });
+    if (list.children.length) { footnotes.appendChild(list); mdEl.appendChild(footnotes); }
+  }
+
+  function addMsg(role,content){
+    const d=document.createElement('div'); d.className='bubble'+(role==='user'?' me':''); d.dataset.role = role;
+    if (role === 'assistant') {
+      d.innerHTML = '<div class="bubble-header"><button type="button" class="copy-btn" title="Antwort kopieren"><span>📋</span><span>kopieren</span></button></div><div class="md">'+md(content)+'</div>';
+    } else { d.innerHTML='<div class="md">'+md(content)+'</div>'; }
+    $('log').appendChild(d); $('log').scrollTop=$('log').scrollHeight;
+    if (role === 'assistant') {
+      const btn = d.querySelector('.copy-btn'); const mdEl = d.querySelector('.md');
+      if (btn && mdEl && navigator.clipboard && navigator.clipboard.writeText) {
+        btn.addEventListener('click', async () => {
+          const txt = mdEl.innerText || ''; if (!txt) return;
+          const originalHTML = btn.innerHTML;
+          try { await navigator.clipboard.writeText(txt); btn.innerHTML = '<span>✔</span><span>kopiert</span>'; setTimeout(()=>{ btn.innerHTML = originalHTML; }, 1200); }
+          catch (err) { btn.innerHTML = '<span>!</span><span>Fehler</span>'; setTimeout(()=>{ btn.innerHTML = originalHTML; }, 1500); }
+        });
+      }
+      enhanceFootnotes(d);
+    }
+  }
+
+  function renderChat(){ $('log').innerHTML=''; const s=active(); if(!s) return; s.messages.forEach(m=>addMsg(m.role,m.content)); }
+  function push(role,content){ const s=active(); s.messages.push({role,content}); s.ts=Date.now(); saveAll(); }
+
+  function setBadge(){ const b=$('domain-badge'); if(S.domain){ b.style.display='inline-flex'; b.textContent='📘 Fachmodus: '+S.domain } else { b.style.display='none' } }
+  function systemPrefix(){
+    const lines=[];
+    if(S.domain){ const map={ 'AEVO':'Antworte fachlich fundiert im AEVO-Kontext mit kurzer Prüfungsrelevanz.', 'Personal':'Antworte als Expertin für Personal/HR mit Praxisbeispiel.', 'Recht':'Antworte juristisch sauber (Normen nennen) und praxisnah.', 'Kommunikation':'Antworte als Trainerin für Kommunikation, klar strukturiert.', 'VWL':'Antworte fachlich fundiert in Volkswirtschaftslehre (IHK-Prüfungskontext).' }; lines.push(map[S.domain]||''); }
+    lines.push(S.gender ? 'Verwende gendergerechte Sprache (neutral, inklusiv, gut lesbar).' : 'Verwende neutrale, nicht gegenderte Sprache.');
+    lines.push('Strukturiere Antworten: 1) Definition/Einordnung 2) Rechts-/Theoriebezug 3) Praxisbeispiel 4) Prüfungsrelevanz 5) kurze Quellenhinweise (falls vorhanden).');
+    return lines.filter(Boolean).join('\n');
+  }
+
+  function buildHistoryArray() {
+    const s = active(); if (!s || !Array.isArray(s.messages)) return []; const msgs = s.messages.slice(-3); return msgs.map(m => ({ role: m.role, content: m.content }));
+  }
+
+  async function send(){
+    const inp=$('in'); const q=inp.value.trim(); if(!q) return; inp.value=''; $('send').disabled=true;
+    try { const hist = JSON.parse(localStorage.getItem('chatHistory')) || []; hist.push({ user: q, bot: '' }); localStorage.setItem('chatHistory', JSON.stringify(hist)); } catch (e) {}
+    push('user',q); renderChat(); push('assistant','⏳ Einen Moment …'); renderChat();
+    try{
+      const historyArray = buildHistoryArray();
+      const payload={ question: systemPrefix()+'\n\n'+q, token: uniqueToken, history: historyArray };
+      const r=await fetch('/api/bot',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+      const text=await r.text();
+      const out=(text && text.trim().toLowerCase()!=='accepted') ? text : 'Ich habe deine Frage erhalten und beantworte sie gleich – bitte erneut senden, falls nichts erscheint.';
+      const s=active(); s.messages[s.messages.length-1]={role:'assistant',content:out}; saveAll();
+      try { const hist = JSON.parse(localStorage.getItem('chatHistory')) || []; if (hist.length) { hist[hist.length-1].bot = out; localStorage.setItem('chatHistory', JSON.stringify(hist)); } } catch (e) {}
+      renderChat();
+    }catch(e){
+      const s=active(); s.messages[s.messages.length-1]={role:'assistant',content:'Es gab ein Verbindungsproblem. Bitte noch einmal senden.'}; saveAll(); renderChat();
+      try { const hist = JSON.parse(localStorage.getItem('chatHistory')) || []; if (hist.length) { hist[hist.length-1].bot = 'ERROR: Verbindung'; localStorage.setItem('chatHistory', JSON.stringify(hist)); } } catch (e) {}
+    }finally{$('send').disabled=false;}
+  }
+
+  function openPalette(list){
+    const pal=$('palette');
+    pal.innerHTML = list.map(s=>`<div class="pal-item" data-id="${s.id}"><span>${s.title}</span><span class="pal-tag">${s.alias}</span></div>`).join('');
+    pal.style.display = list.length ? 'block' : 'none';
+    pal.querySelectorAll('.pal-item').forEach(it=>it.onclick=()=>{const s=SN.find(x=>x.id===it.dataset.id); pal.style.display='none'; if(!s) return; replaceAliasWithText($('in'), s.alias, s.content); $('in').focus();});
+  }
+  function replaceAliasWithText(inp,alias,text){const v=inp.value; const i=v.lastIndexOf(alias); if(i>=0){inp.value=v.slice(0,i)+text+v.slice(i+alias.length);} else {const s=inp.selectionStart; inp.value=v.slice(0,s)+text+v.slice(s);} }
+
+  function renderPM(){
+    const list=$('pm-list');
+    list.innerHTML = SN.map(s=>`
+      <div class="panel" style="padding:1rem;min-height:120px">
+        <div style="display:flex;justify-content:space-between;gap:0.75rem;align-items:center">
+          <div><b>${s.title}</b> <span class="muted">${s.alias}</span></div>
+          <div>
+            <button class="sm-btn pm-use" data-id="${s.id}">Einfügen</button>
+            <button class="sm-btn pm-edit" data-id="${s.id}">Bearb.</button>
+            <button class="sm-btn pm-del" data-id="${s.id}">🗑</button>
+          </div>
+        </div>
+        <div class="muted" style="margin-top:0.5rem;max-height:5em;overflow:hidden">${s.content}</div>
+      </div>`).join('');
+    list.querySelectorAll('.pm-use').forEach(b=>b.onclick=()=>{const s=SN.find(x=>x.id===b.dataset.id); if(!s)return; replaceAliasWithText($('in'), s.alias, s.content); hide($('m-settings')); $('in').focus();});
+    list.querySelectorAll('.pm-edit').forEach(b=>b.onclick=()=>editSnippet(b.dataset.id));
+    list.querySelectorAll('.pm-del').forEach(b=>b.onclick=()=>{SN=SN.filter(x=>x.id!==b.dataset.id); saveAll(); renderPM();});
+  }
+  function editSnippet(id){ const s = id ? (SN.find(x=>x.id===id) || {id:uid(),title:'',alias:'',content:''}) : {id:uid(),title:'',alias:'',content:''}; editingId=s.id; $('pe-title').value=s.title; $('pe-alias').value=s.alias; $('pe-content').value=s.content; show($('m-prompt')); }
+  let editingId=null;
+  $('pm-add').onclick=()=>editSnippet(null);
+  $('pe-cancel').onclick=()=>hide($('m-prompt'));
+  $('pe-save').onclick=()=>{const obj={id:editingId||uid(),title:$('pe-title').value.trim(),alias:$('pe-alias').value.trim(),content:$('pe-content').value.trim()}; if(!obj.alias.startsWith('/')){alert('Alias muss mit / beginnen.');return} const i=SN.findIndex(x=>x.id===obj.id); if(i>=0) SN[i]=obj; else SN.push(obj); saveAll(); hide($('m-prompt')); renderPM();};
+  $('pm-export').onclick=()=>{const blob=new Blob([JSON.stringify(SN,null,2)],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='linda-snippets.json'; a.click(); URL.revokeObjectURL(a.href);};
+  $('pm-import').onclick=()=>{const i=document.createElement('input'); i.type='file'; i.accept='application/json'; i.onchange=async()=>{const f=i.files[0]; if(!f)return; const txt=await f.text(); try{const arr=JSON.parse(txt); if(Array.isArray(arr)){SN=arr; saveAll(); renderPM();}}catch{alert('Import fehlgeschlagen.')}}; i.click();};
+
+  $('send').onclick=send;
+  $('in').addEventListener('keydown',e=>{ if(e.key==='Enter'&&!e.shiftKey){ e.preventDefault(); send(); }});
+  $('in').addEventListener('input',e=>{ const v=e.target.value; const m=v.match(/\/([\w-]{0,24})$/); if(m){ const q=m[1].toLowerCase(); const list=SN.filter(s=>s.alias.toLowerCase().startsWith('/'+q)||s.title.toLowerCase().includes(q)); openPalette(list); } else $('palette').style.display='none'; });
+  document.addEventListener('click',e=>{ if(!e.target.closest('.composer')) $('palette').style.display='none'; });
+
+  $('p-accept').onclick=()=>{hide($('m-privacy'));show($('m-usage'))};
+  $('p-decline').onclick=()=>location.reload();
+  $('u-accept').onclick=()=>{hide($('m-usage')); const s=active(); if(S.greet && s.messages.length===0){ push('assistant','**Willkommen!** Starte deine Trainingseinheit. Nutze Snippets, Fachmodus und kopiere Antworten direkt.'); renderChat(); } };
+
+  applyTheme();
+  const sw=(el,val)=>{el.classList.toggle('on',val)}
+  sw($('sw-gender'),S.gender); $('sw-gender').onclick=()=>{S.gender=!S.gender; sw($('sw-gender'),S.gender); saveAll();}
+  sw($('sw-greet'),S.greet); $('sw-greet').onclick=()=>{S.greet=!S.greet; sw($('sw-greet'),S.greet); saveAll();}
+  document.querySelectorAll('#chip-theme .chip').forEach(c=>c.onclick=()=>{S.theme=c.dataset.val; saveAll(); applyTheme();});
+  $('sel-domain').value=S.domain||'';
+  setBadge();
+  $('s-save').onclick=()=>{S.domain=$('sel-domain').value; saveAll(); setBadge(); hide($('m-settings'));};
+  $('s-close').onclick=()=>hide($('m-settings'));
+  $('btn-settings').onclick=()=>{ renderPM(); show($('m-settings')); };
+
+  $('btn-export-all').onclick=()=>{ const all=Sessions.map(s=>`# ${s.name||'Chat'} (${new Date(s.ts).toLocaleString()})\n\n`+s.messages.map(m=>(m.role==='user'?'Du: ':'Linda: ')+m.content).join('\n\n')).join('\n\n---\n\n'); const blob=new Blob([all],{type:'text/plain'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='linda_all_chats.txt'; a.click(); URL.revokeObjectURL(a.href); };
+  $('btn-clear-all').onclick=()=>{ if(confirm('Wirklich alle Verläufe löschen?')){ Sessions=[]; addSession(); saveAll(); renderSessions(); renderChat(); } };
+  $('btn-new').onclick=addSession;
+
+  document.querySelectorAll('[data-quick]').forEach(chip=>chip.onclick=()=>{ const alias=chip.getAttribute('data-quick'); replaceAliasWithText($('in'), alias, alias+' '); $('in').focus(); });
+
+  ensureFirstSession();
+  renderSessions();
+  renderChat();
+  updateStats();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `linda-trainer.html` experience with dynamic gradient styling and hero stats
- retain existing chatbot features (sessions, snippets, context addon) while highlighting quick actions and copyable answers
- include quick chips and updated layout for a training-focused coaching feel

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69318d292358832495ffa08a4ab05a3a)