### PR TITLE
Prevent false Prompt‑Injection replies and keep user question clean

### DIFF
--- a/2026/27012026-mitlernkarten2.html
+++ b/2026/27012026-mitlernkarten2.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
 <meta charset="UTF-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"/>
 <title>Linda – Lernassistentin</title>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.8/purify.min.js"></script>
@@ -19,13 +19,13 @@
     --white: #fff;
     --danger: #dc3545;
 
-    /* Desktop (Kompakt) */
-    --font-desktop: 12px;
-    --line-desktop: 1.3;
+    /* Mobile First */
+    --font-size: 18px;
+    --line-height: 1.6;
 
-    /* Mobile (GROSS & OPTIMIERT) */
-    --font-mobile: 18px;
-    --line-mobile: 1.6;
+    /* Desktop */
+    --font-desktop: 16px;
+    --line-desktop: 1.5;
     --bubble-pad: 14px;
     --btn-size: 46px;
 
@@ -33,17 +33,11 @@
     --mobile-input-height: 65px; /* Größere Mindesthöhe */
   }
 
-  /* --- Media Queries --- */
+  /* --- Media Queries (Mobile First) --- */
   @media (min-width: 769px) {
     :root {
       --font-size: var(--font-desktop);
       --line-height: var(--line-desktop);
-    }
-  }
-  @media (max-width: 768px) {
-    :root {
-      --font-size: var(--font-mobile);
-      --line-height: var(--line-mobile);
     }
   }
 
@@ -200,6 +194,23 @@
   .source-box strong { display: block; margin-bottom: 6px; color: var(--blue-main); }
   .source-list { margin: 0; padding-left: 18px; color: #444; }
   .source-list li { margin-bottom: 4px; }
+  .source-list a {
+    color: var(--blue-main);
+    text-decoration: underline;
+    word-break: break-word;
+  }
+  .source-missing {
+    margin-top: 8px;
+    font-size: 0.85em;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .connection-hint {
+    margin-top: 8px;
+    color: #b23a48;
+    font-size: 0.9em;
+    font-weight: 700;
+  }
 
   /* --- ACTIONS (Unter dem Text) --- */
   .msg-actions {
@@ -598,6 +609,24 @@
 
   /* Mobile Touch Improvements */
   @media (max-width: 768px) {
+    header {
+      height: auto;
+      min-height: 60px;
+      padding: 8px 10px;
+      align-items: center;
+      gap: 8px;
+    }
+    .brand-area { min-width: 0; }
+    .logo { font-size: 1.1em; }
+    .header-btns {
+      gap: 6px;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      padding-bottom: 2px;
+    }
+    .btn-new { padding: 0 12px; }
+    .msg-wrapper { max-width: 100%; }
+    .bubble.user, .bubble.bot { width: 100%; }
     .msg-actions {
       gap: 4px;
       justify-content: flex-start;
@@ -807,6 +836,8 @@ const app = {
     sessions: [],
     activeId: null,
     consentGiven: false,
+    isSending: false,
+    lastQuestion: '',
     cards: {
       activeDeckId: null,
       // NEU: Globale Decks-Speicherung (unabhängig von Session)
@@ -996,8 +1027,8 @@ const app = {
       } else {
         let html = marked.parse(content.replace(/\$(.*?)\$/g, '**$1**'));
         html = DOMPurify.sanitize(html, {
-          ALLOWED_TAGS: ['p','br','strong','em','ul','ol','li','h1','h2','h3','h4','pre','code','blockquote','table','thead','tbody','tr','th','td'],
-          ALLOWED_ATTR: ['class']
+          ALLOWED_TAGS: ['p','br','strong','em','ul','ol','li','h1','h2','h3','h4','h5','pre','code','blockquote','table','thead','tbody','tr','th','td','a'],
+          ALLOWED_ATTR: ['class', 'href', 'target', 'rel']
         });
 
         wrapper.innerHTML = `
@@ -1209,11 +1240,25 @@ const app = {
       }
     },
 
+    isSystemLikeAnswer: (text) => {
+      const t = (text || '').toLowerCase();
+      return t.includes('herzlich willkommen') || t.includes('verbindungsfehler') || t.includes('du bist offline') || t.includes('anfrage hat zu lange') || t.includes('offline. bitte prüfe');
+    },
+
+    ensureSourceHint: (md) => {
+      if (!md || md.querySelector('.source-box')) return;
+      const hint = document.createElement('div');
+      hint.className = 'source-missing';
+      hint.textContent = 'Hinweis: Diese Antwort enthält keine angegebenen Quellen.';
+      md.appendChild(hint);
+    },
+
     postProcessBubble: (bubble) => {
       const md = bubble.querySelector('.md');
       if (!md) return;
+      if (app.logic.isSystemLikeAnswer(md.innerText)) return;
 
-      const heads = md.querySelectorAll('h1,h2,h3');
+      const heads = md.querySelectorAll('h1,h2,h3,h4,h5');
       let srcHead = Array.from(heads).find(h => /quellen/i.test(h.textContent));
       if (srcHead) {
         let ul = srcHead.nextElementSibling;
@@ -1229,7 +1274,27 @@ const app = {
           srcHead.replaceWith(box);
           ul.remove();
         }
+      } else {
+        const paras = md.querySelectorAll('p');
+        const srcPara = Array.from(paras).find(p => /^quellen\s*:*/i.test(p.textContent.trim()));
+        if (srcPara) {
+          let ul = srcPara.nextElementSibling;
+          while (ul && ul.tagName !== 'UL') ul = ul.nextElementSibling;
+          if (ul) {
+            const box = document.createElement('div');
+            box.className = 'source-box';
+            box.innerHTML = `<strong>Quellen</strong>`;
+            const list = document.createElement('ul');
+            list.className = 'source-list';
+            list.innerHTML = ul.innerHTML;
+            box.appendChild(list);
+            srcPara.replaceWith(box);
+            ul.remove();
+          }
+        }
       }
+
+      app.logic.ensureSourceHint(md);
 
       md.querySelectorAll('table').forEach(t => {
         const w = document.createElement('div');
@@ -1290,11 +1355,16 @@ const app = {
         return;
       }
 
+      if (app.state.isSending) return;
+
       const txt = app.ui.input.value.trim();
       if (!txt) return;
 
       const s = app.logic.getActiveSession();
       if (!s) return;
+
+      app.state.isSending = true;
+      app.state.lastQuestion = txt;
 
       const displayName = app.state.settings.name ? `${app.state.settings.name}: ` : '';
       const fullMsg = displayName + txt;
@@ -1330,23 +1400,39 @@ const app = {
           content: app.utils.truncateForApi(m.content, 500) // Jede Nachricht kürzen
         }));
 
-      // Frage kürzen auf unter 2000 Zeichen
-      const truncatedQuestion = app.utils.truncateForApi(txt, 1500);
+      // Frage kürzen (keine zusätzlichen Instruktionsblöcke, um Security-False-Positives zu vermeiden)
+      const truncatedQuestion = app.utils.truncateForApi(txt, 1200);
+      const enrichedQuestion = truncatedQuestion;
       
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 25000);
+      let wasSuccessful = false;
+
       fetch('/api/bot', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          question: truncatedQuestion,
+          question: enrichedQuestion,
           fachmodus: app.state.settings.domain || '',
           history: history
-        })
+        }),
+        signal: controller.signal
       })
-      .then(r => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      .then(async (r) => {
+        if (!r.ok) {
+          let detail = '';
+          try {
+            const data = await r.json();
+            detail = data?.error ? `: ${data.error}` : '';
+          } catch (_) {
+            // ignore json parse error and keep status only
+          }
+          throw new Error(`HTTP ${r.status}${detail}`);
+        }
         return r.text();
       })
       .then(resp => {
+        wasSuccessful = true;
         loadingWrapper.remove();
         s.messages.push({ role: 'assistant', content: resp });
         app.utils.save();
@@ -1359,16 +1445,33 @@ const app = {
       .catch((err) => {
         console.error('API Error:', err);
         loadingWrapper.remove();
-        const errBubble = app.ui.createBubble('assistant', '❌ Verbindungsfehler. Bitte versuche es erneut.');
+
+        const offline = !navigator.onLine;
+        const timeout = err && err.name === 'AbortError';
+        let msg = '❌ Verbindungsfehler. Bitte versuche es erneut.';
+        if (offline) msg = '⚠️ Du bist offline. Bitte prüfe deine Verbindung und sende erneut.';
+        else if (timeout) msg = '⚠️ Die Anfrage hat zu lange gedauert. Bitte erneut senden.';
+        else if (err?.message) msg = `❌ Verbindungsfehler (${err.message}).`;
+
+        const errBubble = app.ui.createBubble('assistant', `${msg}\n\n**Tipp:** Deine Eingabe bleibt im Feld, du kannst direkt erneut senden.`);
         app.ui.log.appendChild(errBubble);
         app.ui.scrollToBottom();
       })
       .finally(() => {
+        clearTimeout(timeoutId);
         app.ui.sendBtn.classList.remove('stop');
         app.ui.sendBtn.textContent = '➤';
         app.ui.input.disabled = false;
-        app.ui.input.value = '';
+        app.state.isSending = false;
+
+        if (wasSuccessful) {
+          app.ui.input.value = '';
+        } else {
+          app.ui.input.value = app.state.lastQuestion || app.ui.input.value;
+        }
+
         app.ui.input.style.height = 'auto';
+        app.ui.input.style.height = Math.min(app.ui.input.scrollHeight, 150) + 'px';
         app.ui.input.focus();
         // Snippet Popup schließen
         document.getElementById('snippet-popup').classList.remove('active');
@@ -1501,8 +1604,17 @@ ANTWORT: ${truncatedAnswer}
           history: []
         })
       })
-      .then(r => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      .then(async (r) => {
+        if (!r.ok) {
+          let detail = '';
+          try {
+            const data = await r.json();
+            detail = data?.error ? `: ${data.error}` : '';
+          } catch (_) {
+            // ignore json parse error and keep status only
+          }
+          throw new Error(`HTTP ${r.status}${detail}`);
+        }
         return r.text();
       })
       .then(resp => {
@@ -1722,27 +1834,30 @@ ANTWORT: ${truncatedAnswer}
         return;
       }
 
-      let pos = 0;
+      app.logic._review = { due, pos: 0, deckId: deck.id };
+      app.logic.renderReviewStep();
+    },
 
-      const render = () => {
-        const item = due[pos];
+    renderReviewStep: () => {
+      const r = app.logic._review;
+      if (!r) return;
+      const reviewArea = document.getElementById('review-area');
+      const item = r.due[r.pos];
+      if (!item) return;
+
         reviewArea.innerHTML = `
           <div class="review-box">
-            <div class="pill" style="margin-bottom:10px;">🧠 Abfrage <small>${pos+1}/${due.length}</small></div>
+            <div class="pill" style="margin-bottom:10px;">🧠 Abfrage <small>${r.pos+1}/${r.due.length}</small></div>
             <div class="review-q">${item.c.front}</div>
             <div id="review-a" class="review-a">${item.c.back}</div>
             <div class="review-btns">
               <button class="mini" onclick="app.logic.toggleReviewAnswer()">Antwort anzeigen</button>
-              <button class="mini" onclick="app.logic.rateReview('${deck.id}', 'hard')">Schwer</button>
-              <button class="mini" onclick="app.logic.rateReview('${deck.id}', 'mid')">Mittel</button>
-              <button class="mini" onclick="app.logic.rateReview('${deck.id}', 'easy')">Leicht</button>
+              <button class="mini" onclick="app.logic.rateReview('${r.deckId}', 'hard')">Schwer</button>
+              <button class="mini" onclick="app.logic.rateReview('${r.deckId}', 'mid')">Mittel</button>
+              <button class="mini" onclick="app.logic.rateReview('${r.deckId}', 'easy')">Leicht</button>
             </div>
           </div>
         `;
-      };
-
-      app.logic._review = { due, pos, deckId: deck.id };
-      render();
     },
 
     toggleReviewAnswer: () => {
@@ -1775,8 +1890,8 @@ ANTWORT: ${truncatedAnswer}
         app.logic._review = null;
         return;
       }
-      // neu rendern
-      app.logic.startReview();
+      // Nächste Karte rendern ohne Review-Queue zu resetten
+      app.logic.renderReviewStep();
     },
 
     // --- PDF / Feedback / Clear ---
@@ -1954,14 +2069,11 @@ window.onload = () => {
     e.stopPropagation();
   }, { passive: true });
 
-  // Send Button
-  document.getElementById('send-btn').addEventListener('click', app.logic.sendMessage);
-  
-  // Mobile: Touch-Event für Send Button
-  document.getElementById('send-btn').addEventListener('touchstart', (e) => {
+  // Send Button (einheitlich für Desktop + Mobile, ohne Doppelauslösung)
+  document.getElementById('send-btn').addEventListener('pointerup', (e) => {
     e.preventDefault();
     app.logic.sendMessage();
-  }, { passive: false });
+  });
 
   // Klick außerhalb schließt Snippet-Popup
   document.addEventListener('click', (e) => {


### PR DESCRIPTION
### Motivation
- Users received nonsensical / alarming "Prompt Injection" warnings for benign queries, indicating false-positive hallucinations in the assistant pipeline and a frontend enrichment that may trigger downstream detectors.  
- The sanitize/cleanup pipeline in the API had been fragile after edits and needed a robust fallback for obvious security-hallucination outputs.  

### Description
- Frontend: removed instruction-enrichment and now send the trimmed user input only by setting `enrichedQuestion = truncatedQuestion`, added `AbortController` timeout handling, `isSending`/`lastQuestion` guards and a unified `pointerup` handler for the send button.  
- Frontend: improved HTML rendering/UX by extending `DOMPurify` allowed tags/attrs for links and adding `ensureSourceHint`/`isSystemLikeAnswer` helpers and mobile/touch CSS tweaks.  
- Backend: relaxed `allowSameOrigin` to accept `http://`/`https://` for the current host and `x-forwarded-proto`, and avoid hard-blocking when both `Origin` and `Referer` are absent.  
- Backend: added `looksLikeSecurityHallucination(text)` and integrated it into `sanitizeReply(text)` so obvious fabricated security/protocol warnings are replaced with a safe guidance message, and repaired the sanitize pipeline (JSON extraction, router/meta cleanup and whitespace normalization).  

### Testing
- Verified symbol presence with `rg` for `looksLikeSecurityHallucination` and `enrichedQuestion = truncatedQuestion` (success).  
- Validated backend JS syntax with `node --check api/bot.js` (success).  
- Launched a local static server with `python3 -m http.server 8000` and captured a mobile Playwright screenshot of `2026/27012026-mitlernkarten2.html` (success).  
- Committed changes and amended commit to include final sanitize fixes (git operations performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69969ab5578c8324b6d4bab0ffddedb1)