### PR TITLE
Sozialrecht-only mobile flow + DeepSeek expert/fast routing (gpt-5.1 default)

### DIFF
--- a/Linda4/api/linda3.js
+++ b/Linda4/api/linda3.js
@@ -9,7 +9,7 @@ const DEFAULT_SOCIALRECHT_CONFIG = {
   version: '1.0',
   domain: 'SOZIALRECHT',
   routing: {
-    default_model: 'gpt-4.1',
+    default_model: 'gpt-5.1',
     fast_model: 'gpt-4.1-mini',
     judgment_model: 'gpt-5.1',
     judgment_max_output_tokens: 520,
@@ -701,6 +701,8 @@ async function handleSozialrechtChat(req, res, action) {
 
   const history = sanitizeHistory(payload.history || []);
   const forceFast = action === 'deepseek';
+  const requestedResponseMode = String(payload?.routing?.response_mode || '').toLowerCase();
+  const expertRequested = requestedResponseMode === 'expert';
   const fastRequested = forceFast || Boolean(payload.schnellmodus) || String(payload?.routing?.preferred_model || '').toLowerCase() === 'deepseek';
   const judgmentMode = isJudgmentQuestion(question);
   const fastMode = fastRequested && !judgmentMode;
@@ -769,6 +771,7 @@ async function handleSozialrechtChat(req, res, action) {
         meta: {
           domain: 'SOZIALRECHT',
           model: 'deepseek',
+          response_mode: expertRequested ? 'expert' : (requestedResponseMode || 'schnell'),
           fast_mode: true,
           judgment_mode: false,
           deepseek_via_legacy: true,
@@ -797,7 +800,7 @@ async function handleSozialrechtChat(req, res, action) {
     : Number(DEFAULT_SOCIALRECHT_CONFIG.routing.judgment_max_output_tokens || 520);
   const maxOutputTokens = judgmentMode
     ? Math.max(260, Math.min(900, judgmentMaxOutputTokens))
-    : defaultMaxOutputTokens;
+    : (fastMode && expertRequested ? 12000 : defaultMaxOutputTokens);
 
   const systemPrompt = judgmentMode
     ? buildSozialrechtJudgmentSystemPrompt(cfg, useStorage)
@@ -912,6 +915,7 @@ async function handleSozialrechtChat(req, res, action) {
       meta: {
         domain: 'SOZIALRECHT',
         model: activeModel,
+        response_mode: expertRequested ? 'expert' : (requestedResponseMode || (fastMode ? 'schnell' : 'genau')),
         fast_mode: fastMode,
         judgment_mode: judgmentMode,
         gpt5_footer: gpt5FooterActive,

--- a/Linda4/docs/sozialrecht_runtime.json
+++ b/Linda4/docs/sozialrecht_runtime.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "domain": "SOZIALRECHT",
   "routing": {
-    "default_model": "gpt-4.1",
+    "default_model": "gpt-5.1",
     "fast_model": "gpt-4.1-mini",
     "judgment_model": "gpt-5.1",
     "judgment_max_output_tokens": 520,

--- a/Linda4/index.html
+++ b/Linda4/index.html
@@ -3063,11 +3063,11 @@
       <span class="label">Antwortmodus</span>
       <label class="fastmode-choice">
         <input id="compare-main-off" type="radio" name="compare-main" value="off">
-        <span>Standard</span>
+        <span>Genau</span>
       </label>
       <label class="fastmode-choice">
         <input id="compare-main-on" type="radio" name="compare-main" value="on">
-        <span>Canvas</span>
+        <span>Experte</span>
       </label>
     </div>
     <div class="smart-control">
@@ -3362,7 +3362,7 @@
   const REWRITE_API_ENDPOINT = '/api/linda3?action=rewrite';
   const TTS_API_ENDPOINT = '/api/linda3?action=tts';
   const STT_API_ENDPOINT = '/api/linda3?action=stt';
-  const SOZIALRECHT_ONLY_MODE = false;
+  const SOZIALRECHT_ONLY_MODE = true;
   const SOZIALRECHT_DOMAIN_KEY = 'SOZIALRECHT';
   const LEARNING_TEMPLATES_PATH = './docs/learning_templates.json';
   const SOZIALRECHT_CURRICULUM_PATH = './docs/sozialrecht_sgb_i_xii.json';
@@ -7705,10 +7705,10 @@
           const effectiveFastMode = mobileReaderActive
             ? false
             : Boolean(app.state.settings.fastMode && app.state.settings.fastMode.enabled);
-          const compareEnabled = (opts?.autoSpeak || mobileReaderActive)
+          const expertModeEnabled = (opts?.autoSpeak || mobileReaderActive)
             ? false
             : Boolean(app.state.settings.compareMode && app.state.settings.compareMode.enabled);
-          const deepseekRoutingActive = Boolean(effectiveFastMode || compareEnabled);
+          const deepseekRoutingActive = Boolean(effectiveFastMode || expertModeEnabled);
           const effectiveSources = mobileReaderActive
             ? { ...app.state.settings.sources, ...MAKEFLOW_ONLY_SOURCES }
             : app.state.settings.sources;
@@ -7727,7 +7727,8 @@
             history: historyForApi,
             sources: effectiveSources,
             routing: {
-              preferred_model: deepseekRoutingActive ? 'deepseek' : 'default'
+              preferred_model: deepseekRoutingActive ? 'deepseek' : 'gpt-5.1',
+              response_mode: expertModeEnabled ? 'expert' : 'genau'
             },
             ilias: {
               enabled: mobileReaderActive
@@ -7759,99 +7760,53 @@
           };
           lastPayload = payload;
 
-          if (compareEnabled) {
+          if (expertModeEnabled) {
             let makeParsed = { answer: '', sources: [] };
-            let deepParsed = { answer: '', sources: [] };
-            const canvasPayload = {
+            const expertPayload = {
               ...payload,
               schnellmodus: true,
               routing: {
                 ...(payload.routing || {}),
-                preferred_model: 'deepseek'
+                preferred_model: 'deepseek',
+                response_mode: 'expert'
               },
               clientMeta: {
                 ...(payload.clientMeta || {}),
-                channel: 'canvas'
+                channel: 'expert'
               }
             };
 
             try {
-              makeParsed = await app.logic.requestAnswer(DEEPSEEK_API_ENDPOINT, canvasPayload, controller.signal);
+              makeParsed = await app.logic.requestAnswer(DEEPSEEK_API_ENDPOINT, expertPayload, controller.signal);
               makeParsed.answer = app.logic.stripRepeatedIntro(makeParsed.answer, allowIntroForThisTurn);
-              makeParsed = app.logic.enrichAssistantResponse(makeParsed, text, canvasPayload, { channel: 'canvas' });
-              makeParsed.meta = { ...(makeParsed.meta || {}), panelTitle: 'Canvas (DeepSeek)' };
+              makeParsed = app.logic.enrichAssistantResponse(makeParsed, text, expertPayload, { channel: 'expert' });
+              makeParsed.meta = { ...(makeParsed.meta || {}), panelTitle: 'Expertenmodus (DeepSeek)' };
             } catch (e) {
               const shouldFallbackToDefault = DEEPSEEK_API_ENDPOINT !== API_ENDPOINT;
               if (shouldFallbackToDefault) {
                 try {
-                  makeParsed = await app.logic.requestAnswer(API_ENDPOINT, canvasPayload, controller.signal);
+                  makeParsed = await app.logic.requestAnswer(API_ENDPOINT, expertPayload, controller.signal);
                   makeParsed.answer = app.logic.stripRepeatedIntro(makeParsed.answer, allowIntroForThisTurn);
-                  makeParsed = app.logic.enrichAssistantResponse(makeParsed, text, canvasPayload, { channel: 'canvas-fallback' });
-                  makeParsed.meta = { ...(makeParsed.meta || {}), panelTitle: 'Canvas (Fallback)' };
+                  makeParsed = app.logic.enrichAssistantResponse(makeParsed, text, expertPayload, { channel: 'expert-fallback' });
+                  makeParsed.meta = { ...(makeParsed.meta || {}), panelTitle: 'Expertenmodus (Fallback)' };
                 } catch (fallbackErr) {
-                  makeParsed = { answer: `❌ Canvas Fehler: ${fallbackErr?.message || 'unbekannt'}`, sources: [], meta: { panelTitle: 'Canvas' } };
+                  makeParsed = { answer: `❌ Expertenmodus Fehler: ${fallbackErr?.message || 'unbekannt'}`, sources: [], meta: { panelTitle: 'Expertenmodus' } };
                 }
               } else {
-                makeParsed = { answer: `❌ Canvas Fehler: ${e?.message || 'unbekannt'}`, sources: [], meta: { panelTitle: 'Canvas' } };
-              }
-            }
-
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-
-            const deepseekPayload = {
-              ...canvasPayload,
-              routing: {
-                ...(canvasPayload.routing || {}),
-                preferred_model: 'deepseek'
-              },
-              clientMeta: {
-                ...(canvasPayload.clientMeta || {}),
-                channel: 'deepseek'
-              }
-            };
-
-            try {
-              deepParsed = await app.logic.requestAnswer(
-                DEEPSEEK_API_ENDPOINT,
-                deepseekPayload,
-                controller.signal
-              );
-              deepParsed.answer = app.logic.stripRepeatedIntro(deepParsed.answer, allowIntroForThisTurn);
-              deepParsed = app.logic.enrichAssistantResponse(deepParsed, text, deepseekPayload, { channel: 'deepseek' });
-              deepParsed.meta = { ...(deepParsed.meta || {}), panelTitle: 'Schnellmodus (DeepSeek)' };
-            } catch (e) {
-              const shouldFallbackToDefault = DEEPSEEK_API_ENDPOINT !== API_ENDPOINT;
-              if (shouldFallbackToDefault) {
-                try {
-                  deepParsed = await app.logic.requestAnswer(
-                    API_ENDPOINT,
-                    deepseekPayload,
-                    controller.signal
-                  );
-                  deepParsed.answer = app.logic.stripRepeatedIntro(deepParsed.answer, allowIntroForThisTurn);
-                  deepParsed = app.logic.enrichAssistantResponse(deepParsed, text, deepseekPayload, { channel: 'deepseek-fallback' });
-                  deepParsed.meta = { ...(deepParsed.meta || {}), panelTitle: 'Schnellmodus (Fallback)' };
-                } catch (fallbackErr) {
-                  deepParsed = { answer: `❌ Schnellmodus Fehler: ${fallbackErr?.message || 'unbekannt'}`, sources: [], meta: { panelTitle: 'Schnellmodus' } };
-                }
-              } else {
-                deepParsed = { answer: `❌ Schnellmodus Fehler: ${e?.message || 'unbekannt'}`, sources: [], meta: { panelTitle: 'Schnellmodus' } };
+                makeParsed = { answer: `❌ Expertenmodus Fehler: ${e?.message || 'unbekannt'}`, sources: [], meta: { panelTitle: 'Expertenmodus' } };
               }
             }
 
             s.messages.push({
               role: 'assistant',
-              content: `Canvas:\n${makeParsed.answer}\n\nSchnellmodus:\n${deepParsed.answer}`,
-              sources: [],
-              compare: {
-                make: makeParsed,
-                deepseek: deepParsed
-              },
+              content: makeParsed.answer,
+              sources: makeParsed.sources || [],
               meta: {
+                ...(makeParsed.meta || {}),
                 question: text
               }
             });
-            app.ui.log.appendChild(app.ui.createCompareBubble(makeParsed, deepParsed));
+            app.ui.log.appendChild(app.ui.createBubble('assistant', makeParsed.answer, makeParsed.sources, makeParsed.meta));
             if (opts?.autoSpeak) {
               const speaking = app.ui.voicePlaybackRow();
               app.ui.log.appendChild(speaking);

--- a/api/linda3.js
+++ b/api/linda3.js
@@ -8,7 +8,7 @@ const DEFAULT_SOCIALRECHT_CONFIG = {
   version: '1.0',
   domain: 'SOZIALRECHT',
   routing: {
-    default_model: 'gpt-4.1',
+    default_model: 'gpt-5.1',
     fast_model: 'gpt-4.1-mini',
     judgment_model: 'gpt-5.1',
     judgment_max_output_tokens: 520,
@@ -671,6 +671,8 @@ async function handleSozialrechtChat(req, res, action) {
 
   const history = sanitizeHistory(payload.history || []);
   const forceFast = action === 'deepseek';
+  const requestedResponseMode = String(payload?.routing?.response_mode || '').toLowerCase();
+  const expertRequested = requestedResponseMode === 'expert';
   const fastRequested = forceFast || Boolean(payload.schnellmodus) || String(payload?.routing?.preferred_model || '').toLowerCase() === 'deepseek';
   const judgmentMode = isJudgmentQuestion(question);
   const fastMode = fastRequested && !judgmentMode;
@@ -739,6 +741,7 @@ async function handleSozialrechtChat(req, res, action) {
         meta: {
           domain: 'SOZIALRECHT',
           model: 'deepseek',
+          response_mode: expertRequested ? 'expert' : (requestedResponseMode || 'schnell'),
           fast_mode: true,
           judgment_mode: false,
           deepseek_via_legacy: true,
@@ -767,7 +770,7 @@ async function handleSozialrechtChat(req, res, action) {
     : Number(DEFAULT_SOCIALRECHT_CONFIG.routing.judgment_max_output_tokens || 520);
   const maxOutputTokens = judgmentMode
     ? Math.max(260, Math.min(900, judgmentMaxOutputTokens))
-    : defaultMaxOutputTokens;
+    : (fastMode && expertRequested ? 12000 : defaultMaxOutputTokens);
 
   const systemPrompt = judgmentMode
     ? buildSozialrechtJudgmentSystemPrompt(cfg, useStorage)
@@ -882,6 +885,7 @@ async function handleSozialrechtChat(req, res, action) {
       meta: {
         domain: 'SOZIALRECHT',
         model: activeModel,
+        response_mode: expertRequested ? 'expert' : (requestedResponseMode || (fastMode ? 'schnell' : 'genau')),
         fast_mode: fastMode,
         judgment_mode: judgmentMode,
         gpt5_footer: gpt5FooterActive,


### PR DESCRIPTION
### Motivation
- Ein minimalistischer, mobil-fokussierter Fachmodus nur für `SOZIALRECHT` soll erzwungen werden und die UI auf schnellen, kontextbezogenen Arbeitsfluss reduzieren.
- Starkes Priorisieren von DeepSeek für Schnell- und Expertenmodus, während für den "Genau"-Modus ein leistungsfähiges LLM (`gpt-5.1`) genutzt werden soll.
- Linda3-Anbindungen (`/api/linda3`) dürfen in ihrer Struktur nicht zerstört werden, daher nur Routing-/Mode-Logik erweitern, nicht entfernen.
- Im Expertenmodus soll DeepSeek ohne enge Token-Beschränkung als bevorzugter Pfad arbeiten (Fallback-Budget erhöht).

### Description
- Frontend: `Linda4/index.html` wurde auf `SOZIALRECHT` gesperrt (`SOZIALRECHT_ONLY_MODE = true`) und das Antwortmodus-UI von `Standard/Canvas` auf `Genau/Experte` angepasst; Requests enthalten jetzt explizit `routing.response_mode` und nutzen `preferred_model: 'deepseek'` für Schnell/Experte oder `gpt-5.1` für Genau.
- Frontend: Expertenmodus vereinfacht; statt Doppel-Panel (Canvas vs Schnellmodus) liefert jetzt ein einzelnes, fokussiertes DeepSeek-`expert`-Ergebnis zurück (keine Compare-Panel-Ausgabe mehr).
- Backend: `api/linda3.js` und `Linda4/api/linda3.js` Default-Routing gesetzt auf `gpt-5.1`, Parsing von `routing.response_mode` hinzugefügt und `response_mode` in `meta`-Objekte zurückgegeben; bei Expert+Fast-Fallback wurde das mögliche Output-Token-Limit erhöht (`12000`).
- Config: Runtime-Konfig `Linda4/docs/sozialrecht_runtime.json` aktualisiert, um `default_model: "gpt-5.1"` widerzuspiegeln; vorhandene `/api/linda3`-Struktur und bestehende Endpunkte blieben unverändert.

### Testing
- `node --check api/linda3.js` wurde ausgeführt und es wurden keine Syntaxfehler gefunden (erfolgreich).
- `node --check Linda4/api/linda3.js` wurde ausgeführt und es wurden keine Syntaxfehler gefunden (erfolgreich).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b9eb339083249e8732d1a36da326)